### PR TITLE
fix: Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,5 @@
   },
   "config": {
     "sort-packages": true
-  },
-  "version": "1.0.1"
+  }
 }


### PR DESCRIPTION
The manually set version did not match the tag. Removing the version from composer.json removes potential issue with mismatch.